### PR TITLE
Don't change style of tablenotetext mark

### DIFF
--- a/cls/aastex62.cls
+++ b/cls/aastex62.cls
@@ -5096,7 +5096,7 @@ width 0pt\currtabletypesize{\sc Note}---{#1}\vskip1pt}}
 
 \def\tablenotetext#1#2{\vskip1pt{\currtabletypesize\vskip1pt\indent\vrule
 height 11pt depth
-2pt width0pt\relax$^{\hbox to 5pt{$#1$}}$#2\vskip1pt}}
+2pt width0pt\relax$^{\hbox to 5pt{#1}}$#2\vskip1pt}}
 
 \def\tablerefs#1{{\small\vskip3pt\indent\vrule height 11pt depth 2pt
 width 0pt\currtabletypesize{\bf References}---{#1}\vskip1sp}}


### PR DESCRIPTION
Solves issue https://github.com/AASJournals/AASTeX60/issues/81
tablenotetext will keep the same style as tablenotemark